### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Pods/DKNightVersion/README.md
+++ b/Pods/DKNightVersion/README.md
@@ -64,7 +64,7 @@ $ pod install
 Import DKNightVersion header file
 
 ```objectivec
-#import <DKNightVersion/DKNightVersion.h>
+# import <DKNightVersion/DKNightVersion.h>
 ```
 
 ## Usage
@@ -73,8 +73,8 @@ Checkout `DKColorTable.txt` file in your project, which locates in `Pods/DKNight
 
 ```
 NORMAL   NIGHT
-#ffffff  #343434 BG
-#aaaaaa  #313131 SEP
+# ffffff  #343434 BG
+# aaaaaa  #313131 SEP
 ```
 
 And then, set color picker like this
@@ -162,16 +162,16 @@ There is a file called `DKColorTable.txt`
 
 ```
 NORMAL   NIGHT
-#ffffff  #343434 BG
-#aaaaaa  #313131 SEP
+# ffffff  #343434 BG
+# aaaaaa  #313131 SEP
 ```
 
 The first line of this file indicated different themes. **NORMAL is required column**, and others are optional. So if you don't need to integrate different themes in your app, just leave the first column in this file, like this:
 
 ```
 NORMAL
-#ffffff BG
-#aaaaaa SEP
+# ffffff BG
+# aaaaaa SEP
 ```
 
 `NORMAL` and `NIGHT` are two different themes, `NORMAL` is default and for normal mode. `NIGHT` is optional and for night mode.
@@ -180,8 +180,8 @@ You can add multiple columns in this `DKColorTable.txt` file as many as you want
 
 ```
 NORMAL   NIGHT    RED
-#ffffff  #343434  #ff0000 BG
-#aaaaaa  #313131  #ff0000 SEP
+# ffffff  #343434  #ff0000 BG
+# aaaaaa  #313131  #ff0000 SEP
 ```
 
 The last column is the key for a color entry, DKNightVersion use the current `themeVersion` (ex: `NORMAL` `NIGHT` and `RED`) and key (ex: `BG`, `SEP`) to find the corresponding color in DKColorTable.
@@ -197,7 +197,7 @@ You can also add another file into your project and fill your color setting in t
 ```
 // color.txt
 NORMAL   NIGHT
-#ffffff  #343434 BG
+# ffffff  #343434 BG
 ```
 
 And change `file` value
@@ -235,9 +235,9 @@ DKColorPicker DKColorPickerWithColors(UIColor *normalColor, ...);
 + (DKColorPicker)colorPickerWithRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
 + (DKColorPicker)colorPickerWithCGColor:(CGColorRef)cgColor;
 + (DKColorPicker)colorPickerWithPatternImage:(UIImage *)image;
-#if __has_include(<CoreImage/CoreImage.h>)
+# if __has_include(<CoreImage/CoreImage.h>)
 + (DKColorPicker)colorPickerWithCIColor:(CIColor *)ciColor NS_AVAILABLE_IOS(5_0);
-#endif
+# endif
 
 + (DKColorPicker)blackColor;
 + (DKColorPicker)darkGrayColor;
@@ -282,11 +282,11 @@ If your file like this:
 
 ```
 NORMAL   NIGHT    RED
-#ffffff  #343434  #fafafa BG
-#aaaaaa  #313131  #aaaaaa SEP
-#0000ff  #ffffff  #fa0000 TINT
-#000000  #ffffff  #000000 TEXT
-#ffffff  #444444  #ffffff BAR
+# ffffff  #343434  #fafafa BG
+# aaaaaa  #313131  #aaaaaa SEP
+# 0000ff  #ffffff  #fa0000 TINT
+# 000000  #ffffff  #000000 TEXT
+# ffffff  #444444  #ffffff BAR
 ```
 
 Set your image picker in this order:

--- a/Pods/MJExtension/README.md
+++ b/Pods/MJExtension/README.md
@@ -443,7 +443,7 @@ User *user = [User mj_objectWithKeyValues:dict context:context];
 ### <a id="Coding"></a> Coding
 
 ```objc
-#import "MJExtension.h"
+# import "MJExtension.h"
 
 @implementation Bag
 // NSCoding Implementation
@@ -476,7 +476,7 @@ NSLog(@"name=%@, price=%f", decodedBag.name, decodedBag.price);
 ### <a id="Camel_underline"></a> Camel -> underline【统一转换属性名（比如驼峰转下划线）】
 ```objc
 // Dog
-#import "MJExtension.h"
+# import "MJExtension.h"
 
 @implementation Dog
 + (NSString *)mj_replacedKeyFromPropertyName121:(NSString *)propertyName
@@ -502,7 +502,7 @@ NSLog(@"nickName=%@, scalePrice=%f runSpeed=%f", dog.nickName, dog.salePrice, do
 ### <a id="NSString_NSDate"></a> NSString -> NSDate, nil -> @""【过滤字典的值（比如字符串日期处理为NSDate、字符串nil处理为@""）】
 ```objc
 // Book
-#import "MJExtension.h"
+# import "MJExtension.h"
 
 @implementation Book
 - (id)mj_newValueFromOldValue:(id)oldValue property:(MJProperty *)property

--- a/Pods/MJRefresh/README.md
+++ b/Pods/MJRefresh/README.md
@@ -79,7 +79,7 @@ UIView+MJExtension.h        UIView+MJExtension.m
 ```objc
 /** 刷新控件的基类 */
 @interface MJRefreshComponent : UIView
-#pragma mark - 刷新状态控制
+# pragma mark - 刷新状态控制
 /** 进入刷新状态 */
 - (void)beginRefreshing;
 /** 结束刷新状态 */
@@ -87,7 +87,7 @@ UIView+MJExtension.h        UIView+MJExtension.m
 /** 是否正在刷新 */
 - (BOOL)isRefreshing;
 
-#pragma mark - 其他
+# pragma mark - 其他
 /** 根据拖拽比例自动切换透明度 */
 @property (assign, nonatomic, getter=isAutomaticallyChangeAlpha) BOOL automaticallyChangeAlpha;
 @end

--- a/Pods/SDWebImage/README.md
+++ b/Pods/SDWebImage/README.md
@@ -47,7 +47,7 @@ method from the tableView:cellForRowAtIndexPath: UITableViewDataSource method. E
 handled for you, from async downloads to caching management.
 
 ```objective-c
-#import <SDWebImage/UIImageView+WebCache.h>
+# import <SDWebImage/UIImageView+WebCache.h>
 
 ...
 
@@ -316,7 +316,7 @@ $(inherited)
 In the source files where you need to use the library, import the header file:
 
 ```objective-c
-#import <SDWebImage/UIImageView+WebCache.h>
+# import <SDWebImage/UIImageView+WebCache.h>
 ```
 
 ### Build Project

--- a/Pods/pop/README.md
+++ b/Pods/pop/README.md
@@ -37,7 +37,7 @@ Alternatively, you can add the project to your workspace and adopt the provided 
 Pop adopts the Core Animation explicit animation programming model. Use by including the following import:
 
 ```objective-c
-#import <pop/POP.h>
+# import <pop/POP.h>
 ```
 
 or if you're using the embedded framework:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ PS:她的新闻数据源来自于百度API Store里的免费新闻api，
 新手项目，多多包涵，谢谢！有相关问题可以在线留言或发邮件至577528249@qq.com，谢谢！
 
 
-#使用方法
+# 使用方法
 
 
 点击右上角Download Zip按钮，将项目压缩包下载至本地，解压后点击文件夹中TTNews.xcworkspace即可运行。
@@ -111,7 +111,7 @@ PS:她的新闻数据源来自于百度API Store里的免费新闻api，
 
 
 
-#License
+# License
 The MIT License (MIT)
 
 Copyright (c) 2016 YangJunhui


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
